### PR TITLE
Fix MD report encoding, TD rating, and clipboard header order

### DIFF
--- a/opensnpqual_backend.py
+++ b/opensnpqual_backend.py
@@ -548,7 +548,9 @@ class OpenSNPQualCLI:
     
     def save_markdown_results(self, results: List[Dict], output_file: str, summary: Optional[str] = None):
         """Save results to Markdown file with color coding."""
-        with open(output_file, 'w') as f:
+        # UTF-8 is required because the report contains emoji (🟢🔵🟡🔴❌);
+        # Windows' default cp1252 cannot encode them.
+        with open(output_file, 'w', encoding='utf-8') as f:
             f.write(f"# {OPENSNPQUAL_TITLE} -- REPORT\n\n")
             f.write(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
 

--- a/opensnpqual_gui.py
+++ b/opensnpqual_gui.py
@@ -417,8 +417,9 @@ class OpenSNPQualGUI:
                         if value == '-' or value < 0:
                             target_list.append("n/a")
                         else:
-                            level = self.cli.metrics.get_quality_level(metric, value)
-                            # Use Unicode symbols for quality levels
+                            level = self.cli.metrics.get_quality_level(metric, value, domain=domain)
+                            # Tk has no color-font support on Windows, so emoji
+                            # render monochrome — use plain symbols in the GUI.
                             symbol = {
                                 'good':         '✓',
                                 'acceptable':   '○',
@@ -523,10 +524,12 @@ class OpenSNPQualGUI:
     
     def copy_table_to_clipboard(self):
         """Copy table contents to clipboard"""
-        # Build tab-separated text
-        clipboard_text = "Touchstone File\tPassivity (Freq)\tPassivity (Time)\t" \
-                        "Reciprocity (Freq)\tReciprocity (Time)\t" \
-                        "Causality (Freq)\tCausality (Time)\n"
+        # Build tab-separated text. Order must match the tree's column layout:
+        # FREQ metrics first, a blank separator, then TIME metrics.
+        clipboard_text = "Touchstone File\t" \
+                        "Passivity (PQMi, Freq)\tReciprocity (RQMi, Freq)\tCausality (CQMi, Freq)\t" \
+                        "\t" \
+                        "Passivity (PQMa, Time)\tReciprocity (RQMa, Time)\tCausality (CQMa, Time)\n"
         
         for item in self.tree.get_children():
             row_data = [self.tree.item(item)['text']]


### PR DESCRIPTION
## Summary
- `save_markdown_results` now opens the file as UTF-8 so the quality-orb emojis no longer crash on Windows' default cp1252 codec — that's why the MD came out empty.
- GUI treeview classifier now forwards `domain` into `get_quality_level`, so time-domain mV values are graded against the mV thresholds instead of the frequency-domain % thresholds (that's why 3.3 mV was showing ✗ and ~20 mV was showing △).
- `Copy Table` clipboard header re-ordered to match the tree's column layout (3 Freq, blank separator, 3 Time), so pasted tables line up with the data rows.

Closes #32
Closes #33

## Test plan
- [x] CLI run on `example_touchstone/example_list.csv` writes a non-empty `*_result.md` with intact emoji bytes.
- [x] TD column now reports 3.3 mV → 🟢 good, 20.8 mV → 🔴 poor in the MD.
- [x] GUI `Edit → Copy Table`, paste into Excel/Sheets, header row aligns with data columns.
- [x] GUI treeview shows ✓/○/△/✗ using the correct (domain-appropriate) thresholds.